### PR TITLE
Fix and handle new methods

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+janus-client (5.0.0.0+0~mr6.4.0.0) unstable; urgency=medium
+
+  * New release.
+
+ -- Sipwise Jenkins Builder <jenkins@sipwise.com>  Tue, 29 May 2018 10:03:46 +0200
+
 janus-client (5.0.0.0+0~mr6.3.0.0) unstable; urgency=medium
 
   [ sol ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+janus-client (5.0.0.0+0~mr6.5.0.0) unstable; urgency=medium
+
+  * New release.
+
+ -- Sipwise Jenkins Builder <jenkins@sipwise.com>  Tue, 24 Jul 2018 13:34:36 +0200
+
 janus-client (5.0.0.0+0~mr6.4.0.0) unstable; urgency=medium
 
   * New release.

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -337,25 +337,6 @@ class Client {
         });
     }
 
-    attachHandle(handleInfo) {
-        var sessionId = handleInfo.session_id;
-        var handleId = handleInfo.handle_id;
-        var plugin = this.sessions[sessionId].videoRoom();
-
-        switch(handleInfo.plugin_specific.type) {
-            case 'publisher':
-                var room = handleInfo.plugin_specific.room;
-                return plugin.attachPublisherHandle(handleId, room);
-            case 'subscriber':
-                var room = handleInfo.plugin_specific.room;
-                var feed = handleInfo.plugin_specific.feed_id;
-                return plugin.attachListenerHandle(handleId, room, feed);
-            default:
-                return plugin.attachVideoRoomHandle(handleId);
-        }
-
-    }
-
     destroySession(id) {
         return new Promise((resolve, reject)=>{
             this.request({

--- a/src/plugins/handle.js
+++ b/src/plugins/handle.js
@@ -75,6 +75,13 @@ class PluginHandle {
         });
     }
 
+    trickles(candidates) {
+        return this.request({
+            janus: 'trickle',
+            candidates: candidates
+        });
+    }
+
     trickleCompleted() {
         return this.request({
             janus: 'trickle',

--- a/src/plugins/handle.js
+++ b/src/plugins/handle.js
@@ -20,6 +20,7 @@ class PluginHandle {
 
     constructor(options) {
         this.id = options.id;
+        this.opaqueId = options.opaqueId;
         this.plugin = options.plugin;
         this.emitter = new EventEmitter();
         this.connectionState = ConnectionState.disconnected;

--- a/src/plugins/plugin.js
+++ b/src/plugins/plugin.js
@@ -45,9 +45,10 @@ class Plugin {
         this.handles.delete(id);
     }
 
-    createHandle() {
+    createHandle(options) {
         return new Promise((resolve, reject)=>{
-            this.getSession().createPluginHandle(this.getFullName()).then((handleId)=>{
+            this.getSession().createPluginHandle(this.getFullName(), options)
+            .then((handleId)=>{
                 resolve(handleId);
             }).catch((err)=>{
                 reject(err);

--- a/src/plugins/videoroom/handle.js
+++ b/src/plugins/videoroom/handle.js
@@ -8,7 +8,7 @@ var logger = require('debug-logger')('janus:videoroom:handle');
 
 var ParticipantType = {
     publisher: 'publisher',
-    listener: 'listener'
+    listener: 'subscriber'
 };
 
 /**

--- a/src/plugins/videoroom/index.js
+++ b/src/plugins/videoroom/index.js
@@ -112,7 +112,7 @@ class VideoRoomPlugin extends Plugin {
         return new Promise((resolve, reject)=>{
             var handle = null;
             Promise.resolve().then(()=>{
-                return this.createListenerHandle(room);
+                return this.createListenerHandle(room, feed);
             }).then((createdHandle)=>{
                 handle = createdHandle;
                 return handle.createOffer();

--- a/src/plugins/videoroom/index.js
+++ b/src/plugins/videoroom/index.js
@@ -32,10 +32,11 @@ class VideoRoomPlugin extends Plugin {
         this.$defaultHandle = null;
     }
 
-    defaultHandle() {
+    defaultHandle(options) {
         return new Promise((resolve, reject)=>{
             if(this.$defaultHandle === null) {
-                this.createVideoRoomHandle().then((handle)=>{
+                this.createVideoRoomHandle(options)
+                .then((handle)=>{
                     this.$defaultHandle = handle;
                     resolve(this.$defaultHandle);
                 }).catch((err)=>{
@@ -47,9 +48,10 @@ class VideoRoomPlugin extends Plugin {
         });
     }
 
-    createVideoRoomHandle() {
+    createVideoRoomHandle(options) {
         return new Promise((resolve, reject)=>{
-            this.createHandle().then((id)=>{
+            this.createHandle(options)
+            .then((id)=>{
                 this.addHandle(new VideoRoomHandle({
                     id: id,
                     plugin: this
@@ -61,23 +63,28 @@ class VideoRoomPlugin extends Plugin {
         });
     }
 
-    attachVideoRoomHandle(handleId) {
+    attachVideoRoomHandle(handleId, opaqueId) {
         return new Promise((resolve)=>{
             this.addHandle(new VideoRoomHandle({
                 id: handleId,
-                plugin: this
+                plugin: this,
+                opaqueId: opaqueId
             }));
-            resolve(this.getHandle(handleId));
+            var defaultHandle = this.getHandle(handleId);
+            this.$defaultHandle = defaultHandle;
+            resolve(defaultHandle);
         });
     }
 
-    createPublisherHandle(room) {
+    createPublisherHandle(room, opaqueId) {
+        var options = { opaqueId: opaqueId };
         return new Promise((resolve, reject)=>{
-            this.createHandle().then((id)=>{
+            this.createHandle(options).then((id)=>{
                 this.addHandle(new VideoRoomPublisher({
                     id: id,
                     plugin: this,
-                    room: room
+                    room: room,
+                    opaqueId: opaqueId
                 }));
                 resolve(this.getHandle(id));
             }).catch((err)=>{
@@ -86,25 +93,29 @@ class VideoRoomPlugin extends Plugin {
         });
     }
 
-    attachPublisherHandle(handleId, room) {
+    attachPublisherHandle(handleId, room, opaqueId) {
         return new Promise((resolve)=>{
             this.addHandle(new VideoRoomPublisher({
                 id: handleId,
                 plugin: this,
-                room: room
+                room: room,
+                opaqueId: opaqueId
             }));
             resolve(this.getHandle(handleId));
         });
     }
 
-    createListenerHandle(room, feed) {
+    createListenerHandle(room, feed, opaqueId) {
+        var options = { opaqueId: opaqueId };
         return new Promise((resolve, reject)=>{
-            this.createHandle().then((id)=>{
+            this.createHandle(options)
+            .then((id)=>{
                 this.addHandle(new VideoRoomListener({
                     id: id,
                     plugin: this,
                     room: room,
-                    feed: feed
+                    feed: feed,
+                    opaqueId: opaqueId
                 }));
                 resolve(this.getHandle(id));
             }).catch((err)=>{
@@ -113,23 +124,24 @@ class VideoRoomPlugin extends Plugin {
         });
     }
 
-    attachListenerHandle(handleId, room, feed) {
+    attachListenerHandle(handleId, room, feed, opaqueId) {
         return new Promise((resolve)=>{
             this.addHandle(new VideoRoomListener({
                 id: handleId,
                 plugin: this,
                 room: room,
-                feed: feed
+                feed: feed,
+                opaqueId: opaqueId
             }));
             resolve(this.getHandle(handleId));
         });
     }
 
-    publishFeed(room, offer) {
+    publishFeed(room, offer, opaqueId) {
         return new Promise((resolve, reject)=>{
             var handle = null;
             Promise.resolve().then(()=>{
-                return this.createPublisherHandle(room);
+                return this.createPublisherHandle(room, opaqueId);
             }).then((createdHandle)=>{
                 handle = createdHandle;
                 return handle.createAnswer(offer);
@@ -141,11 +153,11 @@ class VideoRoomPlugin extends Plugin {
         });
     }
 
-    listenFeed(room, feed) {
+    listenFeed(room, feed, opaqueId) {
         return new Promise((resolve, reject)=>{
             var handle = null;
             Promise.resolve().then(()=>{
-                return this.createListenerHandle(room, feed);
+                return this.createListenerHandle(room, feed, opaqueId);
             }).then((createdHandle)=>{
                 handle = createdHandle;
                 return handle.createOffer();

--- a/src/session.js
+++ b/src/session.js
@@ -69,7 +69,7 @@ class Session {
     }
 
     createPluginHandle(plugin, options) {
-        var opaqueId = options.opaqueId;
+        var opaqueId = options ? options.opaqueId : undefined;
         return new Promise((resolve, reject)=>{
             this.request({
                 janus: 'attach',

--- a/src/session.js
+++ b/src/session.js
@@ -68,11 +68,13 @@ class Session {
         return this.janus.request(obj, options);
     }
 
-    createPluginHandle(plugin) {
+    createPluginHandle(plugin, options) {
+        var opaqueId = options.opaqueId;
         return new Promise((resolve, reject)=>{
             this.request({
                 janus: 'attach',
-                plugin: plugin
+                plugin: plugin,
+                opaque_id: opaqueId
             }).then((res)=>{
                 var handleId = _.get(res.getResponse(), 'data.id', null);
                 if(handleId !== null) {


### PR DESCRIPTION
- apply trickles to bufferize ICE candidates
- apply claim session to re-attach existing Janus session to the client
- fix legacy "listener" `ptype` to "subscriber"
- fix missing property to listenFeed
- add opaqueId notion