### PR TITLE
Added check for data channels

### DIFF
--- a/src/plugins/videoroom/handle.js
+++ b/src/plugins/videoroom/handle.js
@@ -159,6 +159,7 @@ class VideoRoomHandle extends PluginHandle {
         return new Promise((resolve, reject)=>{
             options.audio = _.get(options, 'audio', true);
             options.video = _.get(options, 'video', true);
+            options.data = _.get(options, 'data', true);
             let message = _.merge({
                 request: 'configure'
             }, options);


### PR DESCRIPTION
Had an issue where data channels weren't working, discovered that in `joinAndConfigure` the function wasn't checking for a data channel. This made it so janus-client wasn't telling the plugin that data channels were going to be used, causing Janus to ignore incoming data channel messages