### PR TITLE
Fixes #5 -- Make janus-client browser compatible

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "janus-videoroom-client",
-  "version": "4.1.0",
+  "version": "4.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -40,9 +40,9 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw=="
     },
     "async-limiter": {
-      "version": "1.0.0",
-      "resolved": "https://npm-registry.sipwise.com/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+      "version": "1.0.1",
+      "resolved": "https://npm-registry.sipwise.com/async-limiter/-/async-limiter-1.0.1.tgz",
+      "integrity": "sha512-csOlWGAcRFJaI6m+F2WKdnMKr4HhdhFVBk0H/QbJFMCr+uO2kwohwXQPxw/9OCxp05r5ghVBFSyioixx3gfkNQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -447,6 +447,11 @@
       "resolved": "https://npm-registry.sipwise.com/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://npm-registry.sipwise.com/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="
     },
     "js-yaml": {
       "version": "3.13.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "chai": "4.2.0",
     "debug-logger": "0.4.1",
+    "isomorphic-ws": "4.0.1",
     "lodash": "4.17.15",
     "uuid": "3.3.2",
     "validator": "11.1.0",

--- a/src/transaction.js
+++ b/src/transaction.js
@@ -94,11 +94,12 @@ class Transaction {
         if(this.state === State.new) {
             this.state = State.started;
             this.startTimeout();
-            this.client.sendObject(this.getRequest()).then(()=>{
+            try {
+                this.client.sendObject(this.getRequest());
                 this.emitter.emit('sent', this.getRequest());
-            }).catch((err)=>{
+            } catch (err) {
                 this.error(err);
-            });
+            }
         } else {
             this.error(new InvalidTransactionState(this));
         }


### PR DESCRIPTION
This uses the isomorphic-ws package and migrates all the internal
code to use the browser style WebSocket API.

Tested in both a browser based web-app and a complex electron app.

This probably warrants a major version bump.