### PR TITLE
fix README: is_private is bool

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ client.createSession().then((session)=>{
 ```javascript
 videoRoomHandle.create({
    publishers: 3,
-   is_private: 'no',
+   is_private: false,
    secret: '****',
    pin: '****',
    audiocodec: 'opus',


### PR DESCRIPTION
is_private now is a bool

`(node:55802) UnhandledPromiseRejectionWarning: PluginError: Invalid element type (is_private should be a boolean)
    at request.then (node_modules/janus-videoroom-client/src/plugins/handle.js:155:28)
    at process._tickCallback (internal/process/next_tick.js:68:7)
(node:55802) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:55802) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.`