### PR TITLE
allow string ids

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "janus-videoroom-client",
-  "version": "4.1.7",
+  "version": "4.1.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/client/index.js
+++ b/src/client/index.js
@@ -72,6 +72,7 @@ class Client {
         this.token = _.get(options, 'token', null);
         this.apiSecret = _.get(options, 'apiSecret', null);
         this.handshakeTimeout = _.get(options, 'handshakeTimeout', undefined);
+        this.allowStringIds = _.isBoolean(options.allowStringIds)? options.allowStringIds : false;
     }
 
     getVersion() {

--- a/src/plugins/videoroom/handle.js
+++ b/src/plugins/videoroom/handle.js
@@ -3,6 +3,7 @@
 const _ = require('lodash');
 const assert = require('chai').assert;
 const PluginHandle = require('../handle').PluginHandle;
+const { parseRoom } = require('./utils');
 
 const ParticipantType = {
     publisher: 'publisher',
@@ -16,6 +17,8 @@ class VideoRoomHandle extends PluginHandle {
 
     constructor(options) {
         super(options);
+
+        this.allowStringIds = options.plugin.allowStringIds;
     }
 
     create(options) {
@@ -38,7 +41,7 @@ class VideoRoomHandle extends PluginHandle {
     destroy(options) {
         return new Promise((resolve, reject)=>{
             assert.property(options, 'room');
-            options.room = parseInt(options.room + "");
+            options.room = parseRoom(options.room + "", this.allowStringIds);
             let message = _.merge({
                 request: 'destroy'
             }, options);
@@ -55,7 +58,7 @@ class VideoRoomHandle extends PluginHandle {
     exists(options) {
         return new Promise((resolve, reject)=>{
             assert.property(options, 'room');
-            options.room = parseInt(options.room + "");
+            options.room = parseRoom(options.room + "", this.allowStringIds);
             let message = _.merge({
                 request: 'exists'
             }, options);
@@ -88,7 +91,7 @@ class VideoRoomHandle extends PluginHandle {
     listParticipants(options) {
         return new Promise((resolve, reject)=>{
             assert.property(options, 'room');
-            options.room = parseInt(options.room + "");
+            options.room = parseRoom(options.room + "", this.allowStringIds);
             let message = _.merge({
                 request: 'listparticipants'
             }, options);
@@ -107,7 +110,7 @@ class VideoRoomHandle extends PluginHandle {
         return new Promise((resolve, reject)=>{
             assert.property(options, 'room');
             assert.property(options, 'ptype');
-            options.room = parseInt(options.room + "");
+            options.room = parseRoom(options.room + "", this.allowStringIds);
             let message = _.merge({
                 request: 'join'
             }, options);
@@ -128,7 +131,7 @@ class VideoRoomHandle extends PluginHandle {
     joinPublisher(options) {
         return new Promise((resolve, reject)=>{
             assert.property(options, 'room');
-            options.room = parseInt(options.room + "");
+            options.room = parseRoom(options.room + "", this.allowStringIds);
             let joinOptions = _.merge({
                 ptype: ParticipantType.publisher
             }, options);
@@ -146,7 +149,7 @@ class VideoRoomHandle extends PluginHandle {
         return new Promise((resolve, reject)=>{
             assert.property(options, 'room');
             assert.property(options, 'feed');
-            options.room = parseInt(options.room + "");
+            options.room = parseRoom(options.room + "", this.allowStringIds);
             options.feed = parseInt(options.feed + "");
             let joinOptions = _.merge({
                 ptype: ParticipantType.listener
@@ -188,7 +191,7 @@ class VideoRoomHandle extends PluginHandle {
             options.audio = _.get(options, 'audio', true);
             options.video = _.get(options, 'video', true);
             options.data = _.get(options, 'data', true);
-            options.room = parseInt(options.room + "");
+            options.room = parseRoom(options.room + "", this.allowStringIds);
             let message = _.merge({
                 request: 'joinandconfigure',
                 ptype: 'publisher'
@@ -247,7 +250,7 @@ class VideoRoomHandle extends PluginHandle {
         return new Promise((resolve, reject)=>{
             assert.property(options, 'room');
             assert.property(options, 'jsep');
-            options.room = parseInt(options.room + "");
+            options.room = parseRoom(options.room + "", this.allowStringIds);
             let message = _.merge({
                 request: 'start'
             }, options);

--- a/src/plugins/videoroom/index.js
+++ b/src/plugins/videoroom/index.js
@@ -28,6 +28,7 @@ class VideoRoomPlugin extends Plugin {
         this.name = 'videoroom';
         this.fullName = 'janus.plugin.' + this.name;
         this.session = options.session;
+        this.allowStringIds = options.allowStringIds;
         this.$defaultHandle = null;
     }
 

--- a/src/plugins/videoroom/listener.js
+++ b/src/plugins/videoroom/listener.js
@@ -2,6 +2,7 @@
 
 const logger = require('debug-logger')('janus:videoroom:listener');
 const VideoRoomHandle = require('./handle').VideoRoomHandle;
+const { parseRoom } = require('./utils');
 
 /**
  * @class
@@ -10,7 +11,7 @@ class VideoRoomListener extends VideoRoomHandle {
 
     constructor(options) {
         super(options);
-        this.room = options.room;
+        this.room = parseRoom(options.room, this.allowStringIds);
         this.feed = options.feed;
         this.offer = null;
     }

--- a/src/plugins/videoroom/publisher.js
+++ b/src/plugins/videoroom/publisher.js
@@ -3,7 +3,7 @@
 const _ = require('lodash');
 const logger = require('debug-logger')('janus:videoroom:publisher');
 const VideoRoomHandle = require('./handle').VideoRoomHandle;
-
+const { parseRoom } = require('./utils');
 /**
  * @class
  */
@@ -12,7 +12,7 @@ class VideoRoomPublisher extends VideoRoomHandle {
     constructor(options) {
         super(options);
         this.publisherId = null;
-        this.room = options.room;
+        this.room = parseRoom(options.room, this.allowStringIds);
         this.answer = null;
     }
 

--- a/src/plugins/videoroom/utils.js
+++ b/src/plugins/videoroom/utils.js
@@ -1,0 +1,14 @@
+/**
+ * Room can be both string and number.
+ * Decide based on 'allowStringIds' param
+ * @param {string|number} roomRaw
+ * @param {boolean} allowStringIds
+ * @returns {string|number}
+ */
+function parseRoom(roomRaw, allowStringIds) {
+    if (allowStringIds) return `${roomRaw}`;
+
+    return parseInt(roomRaw);
+}
+
+module.exports.parseRoom = parseRoom;

--- a/src/session.js
+++ b/src/session.js
@@ -26,7 +26,10 @@ class Session {
         this.emitter = new EventEmitter();
         this.state = (this.janus.isConnected()) ? State.alive : State.dead;
         this.startKeepAlive();
-        this.videoRoomPlugin = new VideoRoomPlugin({ session: this });
+        this.videoRoomPlugin = new VideoRoomPlugin({ 
+            session: this,
+            allowStringIds: janus.allowStringIds,
+        });
     }
 
     keepAlive() {

--- a/test/videoroom-plugin-spec.js
+++ b/test/videoroom-plugin-spec.js
@@ -33,6 +33,15 @@ describe('VideoRoomPlugin', function(){
         });
     });
 
+    it('should return feeds of a room as string', function(done) {
+        session.videoRoom().getFeeds('echo-1234').then((feeds)=>{
+            assert.isArray(feeds);
+            done();
+        }).catch((err)=>{
+            done(err);
+        });
+    });
+
     it('should return feeds of a room excluding a specific feed', function(done) {
         session.videoRoom().getFeedsExclude(1, 1).then((feeds)=>{
             console.log(feeds);


### PR DESCRIPTION
In https://github.com/meetecho/janus-gateway/blob/master/CHANGELOG.md#v091---2020-03-10 was introduced support for string ids. 
This is a PoC. If its fine it would be great to merge it.